### PR TITLE
Update core.get_cmd_by_name method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,0 @@
-git+https://github.com/hsorby/dulwich.git#egg=dulwich --global-option --pure

--- a/setup.py
+++ b/setup.py
@@ -17,16 +17,6 @@ long_description = (
     open(os.path.join('docs', 'CHANGES.rst')).read()
     + '\n')
 
-
-class InstallCommand(install):
-
-    def run(self):
-        install.run(self)
-        # Automatically install requirements from requirements.txt
-        import subprocess
-        subprocess.call(['pip', 'install', '-r', os.path.join(SETUP_DIR, 'requirements.txt')])
-
-
 setup(name='pmr2.wfctrl',
       version=version,
       description="Workflow controller",
@@ -36,7 +26,6 @@ setup(name='pmr2.wfctrl',
       classifiers=[
         "Programming Language :: Python",
         ],
-      cmdclass={'install': InstallCommand,},
       keywords='',
       author='',
       author_email='',
@@ -49,7 +38,7 @@ setup(name='pmr2.wfctrl',
       zip_safe=False,
       install_requires=[
           'setuptools',
-          # 'dulwich',
+          'dulwich',
           # -*- Extra requirements: -*-
       ],
       entry_points="""

--- a/src/pmr2/wfctrl/core.py
+++ b/src/pmr2/wfctrl/core.py
@@ -24,6 +24,14 @@ def register_cmd(*cmd_classes):
             _cmd_names[cmd_cls.name] = cmd_cls
 
 def get_cmd_by_name(cmd_name):
+    cmd_cls = get_cmd_class_by_name(cmd_name)
+    if cmd_cls:
+        return cmd_cls()
+    else:
+        return None
+
+
+def get_cmd_class_by_name(cmd_name):
     return _cmd_names.get(cmd_name)
 
 


### PR DESCRIPTION
Currently the `get_cmd_by_name` method returns a cmd class type rather than a cmd object. This commit changes the name of this method to `get_cmd_class_by_name` as I believe this more accurately reflects its usage.

This also gives us the opportunity to add a new `get_cmd_by_name` implementation which returns an instantiated cmd object. This is useful because the majority of uses of the `get_cmd_by_name` method in the MAP-Client instantiate the cmd object right after getting the class and don't actually need a handle to the type.