### PR TITLE
Add returncode check for Popen error messages

### DIFF
--- a/src/pmr2/wfctrl/cmd.py
+++ b/src/pmr2/wfctrl/cmd.py
@@ -215,7 +215,7 @@ class GitDvcsCmd(BaseDvcsCmdBin):
     def reset_to_remote(self, workspace, branch=None):
         # XXX not actually resetting to remote
         if branch is None:
-            branch, _ = self.execute(
+            branch, _, *_ = self.execute(
                 *self._args(workspace, 'branch', '--show-current'))
             branch = branch.strip()
         args = self._args(workspace, 'reset', '--hard', branch)

--- a/src/pmr2/wfctrl/cmd.py
+++ b/src/pmr2/wfctrl/cmd.py
@@ -172,7 +172,7 @@ class GitDvcsCmd(BaseDvcsCmdBin):
 
     def read_remote(self, workspace, target_remote=None, **kw):
         target_remote = target_remote or self.default_remote
-        stdout, err = self.execute(*self._args(workspace, 'remote', '-v'))
+        stdout, err, return_code = self.execute(*self._args(workspace, 'remote', '-v'))
         if stdout:
             for lines in stdout.splitlines():
                 remotes = lines.decode('utf8', errors='replace').split()
@@ -182,9 +182,9 @@ class GitDvcsCmd(BaseDvcsCmdBin):
 
     def write_remote(self, workspace, target_remote=None, **kw):
         target_remote = target_remote or self.default_remote
-        stdout, err = self.execute(*self._args(workspace, 'remote',
+        stdout, err, return_code = self.execute(*self._args(workspace, 'remote',
             'rm', target_remote))
-        stdout, err = self.execute(*self._args(workspace, 'remote',
+        stdout, err, return_code = self.execute(*self._args(workspace, 'remote',
             'add', target_remote, self.remote))
 
     def pull(self, workspace, username=None, password=None, **kw):

--- a/src/pmr2/wfctrl/core.py
+++ b/src/pmr2/wfctrl/core.py
@@ -301,7 +301,13 @@ class BaseDvcsCmdBin(BaseDvcsCmd):
             extra_kw['preexec_fn'] = os.setsid
 
         p = Popen(cmdargs, stdin=PIPE, stdout=PIPE, stderr=PIPE, **extra_kw)
-        return p.communicate()
+        out, err = p.communicate()
+
+        if err and not p.returncode:
+            out = out + err
+            err = b''
+
+        return out, err
 
     # public class method because this is useful before class is
     # instantiated.

--- a/src/pmr2/wfctrl/core.py
+++ b/src/pmr2/wfctrl/core.py
@@ -301,13 +301,7 @@ class BaseDvcsCmdBin(BaseDvcsCmd):
             extra_kw['preexec_fn'] = os.setsid
 
         p = Popen(cmdargs, stdin=PIPE, stdout=PIPE, stderr=PIPE, **extra_kw)
-        out, err = p.communicate()
-
-        if err and not p.returncode:
-            out = out + err
-            err = b''
-
-        return out, err
+        return p.communicate() + (p.returncode,)
 
     # public class method because this is useful before class is
     # instantiated.

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -84,8 +84,8 @@ class BaseDvcsCmdBinTestCase(TestCase):
         # Pretend we have a binary here too
         vcs = BaseDvcsCmdBin(cmd_binary='python')
         self.assertTrue(isinstance(vcs, BaseDvcsCmdBin))
-        # (stdout, stderr)
-        self.assertEqual(len(vcs.execute()), 2)
+        # (stdout, stderr, return_code)
+        self.assertEqual(len(vcs.execute()), 3)
 
     def test_dvcs_default_fails(self):
         cmd = BaseDvcsCmdBin(cmd_binary='python')


### PR DESCRIPTION
We are currently encountering an issue while using the `subprocess.Popen` class for Git push commands. All committed changes are successfully pushed to PMR and are visible in the workspace when viewing it online. However, the `communicate` method called subsequently on the `Popen` object contains the following text in the `stderr` stream.

![stderr](https://github.com/tsalemink/pmr2.wfctrl/assets/82302710/bcb82e1d-124c-49eb-a8dc-c07d29010ba4)

If we copy the Git push command generated by the `DvcsCmd` object and run it manually from the command line we get the following full output:

![Full](https://github.com/tsalemink/pmr2.wfctrl/assets/82302710/17645688-d2b1-4be6-9d43-c7dafe4733c6)

This seems to show that there isn't actually an error occurring but part of the return message is being mistakenly output to the stderr stream. Additionally, the return code given by the `Popen` object is 0.

Currently the MAP-Client checks if anything has been returned in the `stderr` stream from the push command and logs anything it finds as an error, but we would like to avoid this message showing as an error as this is misleading for MAP-Client users trying to push workflow changes to PMR. Ideally, we would only log the `stderr` stream as an error if the return code is non-zero, and log it as INFO otherwise.

One solution is for the `DvcsCmd` push command to output the return code in addition to returning `p.communicate()` - which gives only the `stdout` and `stderr` streams. Unfortunately this may cause issues since a number of `DvcsCmd` methods (`clone`, `add`, `push`, etc.) all rely on the `_execute` method and pass on its return values, therefore any code already using the existing methods would break since the number of return values has been changed.

The alternative - which I have implemented here - is to check the return code within the `BaseDvcsCmdBin._execute` method and move any invalid "error" messages to the `stdout` stream. Then the message returned would be logged as info rather than an error in the MAP-Client. This isn't ideal but seems like the safest solution. I am open to suggestions if you have a better idea.