### PR TITLE
Enable cloning of private PMR repositories

### DIFF
--- a/src/pmr2/wfctrl/cmd.py
+++ b/src/pmr2/wfctrl/cmd.py
@@ -243,12 +243,12 @@ class AuthenticatedGitDvcsCmd(GitDvcsCmd):
 
     def pull(self, workspace, **kw):
         self._authenticate(workspace)
-        target = self.read_remote(workspace, target_remote=self.remote)
+        target = self.read_remote(workspace)
         return self.execute(*self._args(workspace, 'pull', target))
 
     def push(self, workspace, **kw):
         self._authenticate(workspace)
-        target = self.read_remote(workspace, target_remote=self.remote)
+        target = self.get_remote(workspace)
         return self.execute(*self._args(workspace, 'push', target))
 
 
@@ -382,7 +382,7 @@ class AuthenticatedDulwichDvcsCmd(DulwichDvcsCmd):
 
     def pull(self, workspace, **kw):
         pool_manager = self._authenticate_pool_manager()
-        target = self.read_remote(workspace, target_remote=self.remote)
+        target = self.read_remote(workspace)
         out_stream = BytesIO()
         err_stream = BytesIO()
         try:
@@ -402,7 +402,7 @@ class AuthenticatedDulwichDvcsCmd(DulwichDvcsCmd):
 
     def push(self, workspace, **kw):
         pool_manager = self._authenticate_pool_manager()
-        target = self.read_remote(workspace, target_remote=self.remote)
+        target = self.read_remote(workspace)
         out_stream = BytesIO()
         err_stream = BytesIO()
         try:


### PR DESCRIPTION
Currently, using a `CmdWorkspace` to clone private PMR repositories is not well supported. This is because when we instantiate a `CmdWorkspace` object either `init` or `clone` will be automatically called on the `Cmd` instance used by the `CmdWorkspace`, but there is no way to pass user credentials to the `CmdWorkspace` constructor. So, for private repositories, either `clone` will fail due to lack of authentication, or `init` will create an empty .git directory - preventing subsequent `clone` commands from using that directory.

To address this issue a number of changes must be made:
- `username` and `password` parameters should be added to the `clone` method for each of the `Cmd` sub-classes (`DulwichDvcsCmd`, `GitDvcsCmd`, `MercurialDvcsCmd`).
- A `NotGitRepository` check should be added to the `DulwichDvcsCmd` `read_remote` method, since it may be called before the .git directory has been created. (The enclosing `get_remote` method already handles the fallback case where no remote is returned by `read_remote`)

Additionally, we need to prevent the `CmdWorkspace` from automatically calling the non-authenticated `clone` method on initialisation, since this will throw an authentication error for private repositories. There are a few alternatives I can think of for this:
- Remove the automatic calls to `init` and `clone` entirely. In this case the user would need to call these methods explicitly when required after creating a `CmdWorkspace`. (This change will break most of the test cases)
- Add additional prameters to the `CmdWorkspace` constructor to support passing user credentials.
- Have the `clone` methods check for authentication errors so that we can warn the user and skip without crashing.

@metatoaster, @hsorby, let me know what you think about the last part. Maybe you can come up with a better solution.

I will update the test cases if required after the remaining changes have been made.